### PR TITLE
Avoid `'NoneType' object is not iterable` when running in "Check Mode"

### DIFF
--- a/roles/ha/tasks/main.yml
+++ b/roles/ha/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Assign new resources to HA Group
   run_once: true
+  when: not ansible_check_mode
   block:
     - name: Get HA resources from PVE
       ansible.builtin.uri:


### PR DESCRIPTION
When running with `--check`, the task: "Get HA resources from PVE" is skipped, and `resources` is null.

`The conditional check 'item.1 not in ( resources.json.data | json_query(jmesquery) | list )' failed. The error was: Unexpected templating type error occurred on ({% if item.1 not in ( resources.json.data | json_query(jmesquery) | list ) %} True {% else %} False {% endif %}): 'NoneType' object is not iterable. 'NoneType' object is not iterable`